### PR TITLE
Preparations for first release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 [name of plugin creator]
+Copyright (c) 2021 Nebulab SRLs
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solidus Feeds
 
-[![CircleCI](https://circleci.com/gh/nebulab/solidus_feeds.svg?style=shield)](https://circleci.com/gh/nebulab/solidus_feeds)
-[![codecov](https://codecov.io/gh/nebulab/solidus_feeds/branch/master/graph/badge.svg)](https://codecov.io/gh/nebulab/solidus_feeds)
+[![CircleCI](https://circleci.com/gh/solidusio-contrib/solidus_feeds.svg?style=shield)](https://circleci.com/gh/solidusio-contrib/solidus_feeds)
+[![codecov](https://codecov.io/gh/solidusio-contrib/solidus_feeds/branch/master/graph/badge.svg)](https://codecov.io/gh/solidusio-contrib/solidus_feeds)
 
 <!-- Explain what your extension does. -->
 A framework for producing and publishing feeds on Solidus.
@@ -243,4 +243,4 @@ Please refer to the dedicated [page](https://github.com/solidusio/solidus/wiki/H
 
 ## License
 
-Copyright (c) 2020 [name of extension author], released under the New BSD License.
+Copyright (c) 2021 Nebulab SRLs, released under the New BSD License.

--- a/lib/solidus_feeds/publishers/static_file.rb
+++ b/lib/solidus_feeds/publishers/static_file.rb
@@ -9,10 +9,8 @@ module SolidusFeeds
         @path = path
       end
 
-      def call
-        File.open(path, 'w') do |file|
-          yield file
-        end
+      def call(&block)
+        File.open(path, 'w', &block)
       end
     end
   end

--- a/solidus_feeds.gemspec
+++ b/solidus_feeds.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
-  spec.add_development_dependency 'solidus_dev_support', '~> 2.1'
+  spec.add_development_dependency 'solidus_dev_support', '~> 2.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ require 'solidus_dev_support/rspec/feature_helper'
 Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
 # Requires factories defined in lib/solidus_feeds/testing_support/factories.rb
-require 'solidus_feeds/testing_support/factories'
+SolidusDevSupport::TestingSupport::Factories.load_for(SolidusFeeds::Engine)
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
After moving the extension to its new `solidusio-contrib` home, we needed to polish it for the first gem release.

- [x] Link the correct organisation in the README badges
- [x] Update author
- [x] Update extension to the latest `solidus_dev_support` release