### PR TITLE
Fix examples in README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.7'
 end
 
 gemspec


### PR DESCRIPTION
We need to wrap initializer code in a `config.to_prepare` block
in order to work with Zeitwerk in Rails 7.

Also the required `host:` argument was missing for Google Merchant Feed
generator.

Last but not least a feed can only be published if found via

    SolidusFeeds.configuration.find