### PR TITLE
Run tests with Ruby >= 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,21 @@ orbs:
 
 jobs:
   run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: "3.3"
     steps:
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
+    executor:
+      name: solidusio_extensions/mysql
+      ruby_version: "3.2"
     steps:
       - solidusio_extensions/run-tests
   lint-code:
-    executor: solidusio_extensions/sqlite-memory
+    executor:
+      name: solidusio_extensions/sqlite-memory
+      ruby_version: "3.1"
     steps:
       - solidusio_extensions/lint-code
 


### PR DESCRIPTION
Current Solidus 4.4 dropped Ruby 3.0 support.