### PR TITLE
use github action for ci

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,1 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: false
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - pinned
-  - security
-# Label to use when marking an issue as stale
-staleLabel: stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It might be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+_extends: .github

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [pull_request]
+
+concurrency:
+  group: lint-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  ruby:
+    name: Check Ruby
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Lint Ruby files
+        run: bundle exec rubocop -ESP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 4" # every Thursday
+
+concurrency:
+  group: test-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  rspec:
+    name: Solidus ${{ matrix.solidus-branch }}, Rails ${{ matrix.rails-version }} and Ruby ${{ matrix.ruby-version }} on ${{ matrix.database }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: true
+      matrix:
+        rails-version:
+          - "7.0"
+          - "7.1"
+          - "7.2"
+        ruby-version:
+          - "3.1"
+          - "3.4"
+        solidus-branch:
+          - "v4.1"
+          - "v4.2"
+          - "v4.3"
+          - "v4.4"
+          - "v4.5"
+        database:
+          - "postgresql"
+          - "mysql"
+          - "sqlite"
+        exclude:
+          - rails-version: "7.2"
+            solidus-branch: "v4.3"
+          - rails-version: "7.2"
+            solidus-branch: "v4.2"
+          - rails-version: "7.2"
+            solidus-branch: "v4.1"
+          - rails-version: "7.1"
+            solidus-branch: "v4.2"
+          - rails-version: "7.1"
+            solidus-branch: "v4.1"
+          - ruby-version: "3.4"
+            rails-version: "7.0"
+    env:
+      CODECOV_COVERAGE_PATH: ./coverage/coverage.xml
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run extension tests
+        uses: solidusio/test-solidus-extension@main
+        with:
+          database: ${{ matrix.database }}
+          rails-version: ${{ matrix.rails-version }}
+          ruby-version: ${{ matrix.ruby-version }}
+          solidus-branch: ${{ matrix.solidus-branch }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.CODECOV_COVERAGE_PATH }}


### PR DESCRIPTION
This PR is sponsored by :volcano: [Magma Labs](https://github.com/magma-labs)

Current `circle-ci` config seems to be broken. And since `solidus_dev_support` already generate github actions setup. Add it in order to use for ci.


